### PR TITLE
Migrate to images from scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,13 @@ COPY pkg/ pkg/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o service main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:latest
+# Certificates
+FROM alpine:latest as certs
+RUN apk --update add ca-certificates
+
+FROM scratch
 LABEL source = git@github.com:michal-hudy/mockice.git
 WORKDIR /
 COPY --from=builder /workspace/service .
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ENTRYPOINT ["/service"]


### PR DESCRIPTION
Migrate Docker images from distroless to scratch for security improvements.